### PR TITLE
fix: runtime crashes on bundled deploy (fetch binding + signal serialization) — 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 2.4.0
+
+### Fixed
+
+- **Illegal invocation on first API call when bundled.** `fetch` is now invoked
+  with `globalThis` as its receiver (`fetch.call(globalThis, …)`), preventing the
+  `TypeError: Illegal invocation` thrown by minified production builds on
+  Authenticate/login.
+- **`signal` serialized into `ExecuteMultiCall`.** The batched-call payload no
+  longer copies queue-entry internals (`signal`, `resolve`, `reject`) into the
+  JSON-RPC params; only `method` and `params` are sent per call.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "module": "./esm/index.js",
   "author": "Fairfleet Gmbh",
   "license": "MIT",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "keywords": [
     "geotab",
     "api",

--- a/src/internal/call.test.ts
+++ b/src/internal/call.test.ts
@@ -41,3 +41,18 @@ test("Should throw on bad HTTP status", async () => {
 
   await expect(call({ method: "Test" })).rejects.toThrow("HTTP status 500");
 });
+
+test("Should invoke fetch bound to globalThis (guards against Illegal invocation when bundled)", async () => {
+  let receivedThis: unknown = "unset";
+  vi.mocked(fetch).mockImplementation(function (this: unknown) {
+    receivedThis = this;
+    return Promise.resolve({
+      ok: true,
+      text: async () => JSON.stringify({ result: "ok" }),
+    }) as never;
+  });
+
+  await call({ method: "Test" });
+
+  expect(receivedThis).toBe(globalThis);
+});

--- a/src/internal/call.ts
+++ b/src/internal/call.ts
@@ -10,7 +10,7 @@ export function getCall(options: GeotabOptions) {
   const parseJSON = options.parseJSON ?? parseJsonWithDates;
 
   return async function call({ method, params, signal }: Call) {
-    const httpResponse = await fetch(url, {
+    const httpResponse = await fetch.call(globalThis, url, {
       body: JSON.stringify({
         id: nanoid(),
         method,

--- a/src/internal/queue.test.ts
+++ b/src/internal/queue.test.ts
@@ -180,6 +180,27 @@ test("First request should define timeout", async () => {
   await expect(call2).resolves.toBe("test2");
 });
 
+test("Should serialize only method+params into ExecuteMultiCall (no signal/resolve/reject)", async () => {
+  getResult.mockResolvedValueOnce(["a", "b"]);
+  const controller = new AbortController();
+
+  const c1 = callQueued({ method: "Test", params: { x: 1 }, signal: controller.signal });
+  const c2 = callQueued({ method: "Test", params: { y: 2 } });
+
+  vi.advanceTimersToNextTimer();
+  await Promise.all([c1, c2]);
+
+  expect(getResult).toHaveBeenCalledWith({
+    method: "ExecuteMultiCall",
+    params: {
+      calls: [
+        { method: "Test", params: { x: 1 } },
+        { method: "Test", params: { y: 2 } },
+      ],
+    },
+  });
+});
+
 function noop() {
   // ignore
 }

--- a/src/internal/queue.ts
+++ b/src/internal/queue.ts
@@ -92,7 +92,10 @@ export function queue(options: GeotabOptions) {
         return [await next(calls[0])];
       }
 
-      return await next({ method: "ExecuteMultiCall", params: { calls } });
+      return await next({
+        method: "ExecuteMultiCall",
+        params: { calls: calls.map(({ method, params }) => ({ method, params })) },
+      });
     }
 
     return async function middleware(call: Call) {


### PR DESCRIPTION
## Summary
Fixes two runtime bugs that crash the add-in on deploy/login (minified prod builds). Release **2.4.0**. Runtime-only — no `src/types/**` changes.

### 1. `TypeError: Illegal invocation` on first API call (`src/internal/call.ts`)
Minified bundles emit `module.fetch(url)`, calling native `fetch` with `this=module`. Fix: `fetch.call(globalThis, url, …)`. Matches the patch already proven in production in a sibling app.

### 2. `signal` serialized into `ExecuteMultiCall` (`src/internal/queue.ts`)
The multicall batcher copied whole queue entries (incl. `AbortSignal` → `{}`, plus `resolve`/`reject`) into the JSON-RPC payload. Fix: send only `{ method, params }` per call.

## Tests
- TDD red→green for both fixes; full suite **37/37** (`pnpm test`).
- Built bundles verified: `.call(globalThis` present and `calls.map(...)` projection in both `dist/index.js` + `dist/esm/index.js`.

## Review
Independent code review: no issues at/above threshold. Abort handling + result dispatch confirmed intact (original `calls` array untouched); `params`-omission is strictly cleaner; `fetch.call(globalThis)` correct on both node-ponyfill and browser paths.

## Consumer follow-ups (separate, after publish)
- `ecoapp-web`: drop `patches/@fairfleet__geotab@2.3.0.patch` + `omitSignalFromSerializedCalls` middleware; bump to `^2.4.0`.
- `ecoapp-addin-dev`: bump to `^2.4.0`, then migrate to prod.