### PR TITLE
ci: install .NET 6 in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup .NET 6 (required by tools/CaroKann type generator)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.0.x"
+
       - uses: pnpm/action-setup@v2.0.1
         name: Install pnpm
         id: pnpm-install


### PR DESCRIPTION
## Why
`publish.yaml` failed on the 2.4.0 merge: `tools/CaroKann` (type generator) targets **net6.0**, but `ubuntu-latest` (now ubuntu-24.04) no longer ships the .NET 6 runtime — only 8/9/10. The `pnpm build` → `build:types` step aborts with `Microsoft.NETCore.App 6.0.0 not found`, so Publish/tag never run. This blocks *any* release, not just 2.4.0.

## Fix
Add `actions/setup-dotnet@v4` (`6.0.x`) after checkout so CaroKann's runtime is present. Type generation is unchanged.

## Effect
Merging this re-triggers `publish.yaml`; with .NET 6 available the build proceeds and **2.4.0 publishes** (npm currently at 2.3.0).

Note: longer-term, retargeting CaroKann to net8 would drop the EOL-6 dependency, but that's a separate, riskier change.