### PR TITLE
ci: fix npm publish (replace deprecated npm-publish@v1)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,23 +55,23 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - id: publish
-        name: Publish
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          package: ./dist/package.json
+      - name: Publish
+        working-directory: ./dist
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag
-        if: steps.publish.outputs.type != 'none'
+        if: success()
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           pnpm create-git-tag
 
       - name: Push changes
-        if: steps.publish.outputs.type != 'none'
+        if: success()
         uses: ad-m/github-push-action@master
         with:
           tags: true


### PR DESCRIPTION
## Root cause of the 2.4.0 publish failures
After the .NET 6 fix, Build/Test/pack all pass, but the **Publish** step fails with `E404 PUT @fairfleet%2fgeotab` even with a token verified to have `@fairfleet/geotab: read-write`. A 404-on-PUT with a valid token = the request reached npm **unauthenticated**.

Cause: `JS-DevTools/npm-publish@v1` is deprecated (current v4) and has a known bug — it *erroneously writes auth to `.npmrc`* in a way that no longer works with the runner's modern npm / forced Node 24. The token never reaches npm.

## Fix
Replace the action with the npm-documented CI publish pattern: write `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and run `npm publish --access public` from `dist/`, with `NODE_AUTH_TOKEN` from the `NPM_TOKEN` secret. Tag/push steps now gate on `if: success()` (the removed action's `outputs.type` no longer exists).

## Effect
Merging re-triggers `publish.yaml`; with auth actually applied, **2.4.0 publishes** (npm currently 2.3.0) and `v2.4.0` is tagged.

Note: other actions (checkout@v2, cache@v3, codecov@v3, pnpm-action@v2) emit Node-20 deprecation warnings but still work — out of scope here.